### PR TITLE
Script majic edigeo

### DIFF
--- a/copie_donnee_majic_commune.sh
+++ b/copie_donnee_majic_commune.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Script qui sert à rechercher les codes communes dans les fichiers majic pour copier les données par communes dans un dossier correspondant
+# Se lance à partir de la fenetre de commande shell à l'endroit ou se situent les fichiers MAJIC a copier
+
+# 1. Indiquer l'arborescence de sortie (chemin ci dessous en exemple).
+chemin=C:/Users/rjault/Documents/08-CYGWIN_FANTOIR/02-TEST
+
+# 2. Indiquer le chemin d'acces du fichier texte dans lequel se trouve les code communes (chemin ci dessous en exemple).
+fichier_code_commune=C:/Users/rjault/Documents/08-CYGWIN_FANTOIR/02-TEST/commune_test.txt
+
+# 3. Creation d'un dossier COMMUNES pour ranger à l'intérieur les données MAJIC par code INSEE
+mkdir $chemin/COMMUNES
+
+# 4. Initialisation de la boucle: elle s'active pour chaque code commune indiqué dans le fichier commune.txt situé dans le même repertoire
+for commune in $(cat $fichier_code_commune)
+
+	do
+		# 4.1. Création du dossier de la commune avec pour nom le code INSEE de la commune
+		mkdir $chemin/COMMUNES/$commune
+
+		# 4.2. Création du code a rechercher dans le fichier majic code dep + 1 + code commune
+		recherche="`expr substr $commune 1 2`1`expr substr $commune 3 5`"
+
+		# 4.3 Fonction egrep pour copier les fichiers MAJIC dans les dossiers
+		egrep ^$recherche 591_NORD_FANTOIR.txt > $chemin/COMMUNES/$commune/591_NORD_FANTOIR.txt
+		egrep ^$recherche ART.DC21.W19591.BATI.A2019.N001188_2 > $chemin/COMMUNES/$commune/ART.DC21.W19591.BATI.A2019.N001188
+		egrep ^$recherche ART.DC21.W19591.LLOC.A2019.N001188 > $chemin/COMMUNES/$commune/ART.DC21.W19591.LLOC.A2019.N001188
+		egrep ^$recherche ART.DC21.W19591.NBAT.A2019.N001188 > $chemin/COMMUNES/$commune/ART.DC21.W19591.NBAT.A2019.N001188
+		egrep ^$recherche ART.DC21.W19591.PDLL.A2019.N001188 > $chemin/COMMUNES/$commune/ART.DC21.W19591.PDLL.A2019.N001188
+		egrep ^$recherche ART.DC21.W19591.PROP.A2019.N001188 > $chemin/COMMUNES/$commune/ART.DC21.W19591.PROP.A2019.N001188
+		
+		# 4.4. Zip des fichiers dans le repertoire de la commune
+		zip -r -j  $chemin/COMMUNES/$commune/$commune.zip $chemin/COMMUNES/$commune/
+	done
+echo les fichiers sont copies
+
+
+

--- a/extract_donnee_edigeo_commune.sh
+++ b/extract_donnee_edigeo_commune.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Script qui sert à exporter les données EDIGEO par commune.
+# Se lance à partir de la fenetre shell à l'endroit ou se situent le dossier zip des données EDIGEO a copier
+
+# 1. Indiquer l'arborescence de sortie des données (chemin ci dessous en exemple).
+chemin=P:/DGI/MEL_2020
+
+# 2. Indiquer le chemin d'acces du fichier dans lequel se trouve les codes communes (chemin ci dessous en exemple)
+fichier_code_commune=V:/PROJET/08-CYGWIN_FANTOIR/02-TEST/commune.txt
+
+# 3. Creation d'un dossier COMMUNES_EDIGEO pour ranger à l'intérieur les données EDIGEO par code INSEE
+mkdir $chemin/COMMUNES_EDIGEO
+
+# 4. Initialisation de la boucle: elle s'active pour chaque code commune indiqué dans le fichier commune.txt situé dans le même repertoire
+for commune in $(cat $fichier_code_commune)
+
+	do
+		#extraction des données edigeo de la commune dans le dossier COMMUNES_EDIGEO
+		unzip P:/DGI/MEL_2020/dep59.zip $commune/* -d $chemin/COMMUNES_EDIGEO/
+	done
+echo les fichiers sont copies


### PR DESCRIPTION
Cette 'pull request' sert à ajouter deux fichiers dans le dossier SQL_scripts:

1. copie_donnee_majic_commune.sh: Script qui sert à rechercher les codes communes dans les fichiers majic pour copier les données par communes dans un dossier correspondant.

2.  extract_donnee_majic_commune.sh: Script qui sert à exporter les données EDIGEO par commune.